### PR TITLE
Feature/improve cartesian to geodetic accuracy

### DIFF
--- a/src/geodetic.mjs
+++ b/src/geodetic.mjs
@@ -1,3 +1,8 @@
+// Constants for WGS84 ellipsoid
+const a = 6378137; // semi-major axis
+const f = 1 / 298.257223563; // flattening
+const e = Math.sqrt(2 * f - f * f); // eccentricity
+
 /**
  * Convert a geodetic coordinate to a Cartesian coordinate.
  *
@@ -7,11 +12,6 @@
  * @returns {number[]} A Cartesian coordinate as [x, y, z].
  */
 function geodeticToCartesian(lon, lat, alt) {
-    // Constants for WGS84 ellipsoid
-    const a = 6378137; // semi-major axis
-    const f = 1 / 298.257223563; // flattening
-    const e = Math.sqrt(2 * f - f * f); // eccentricity
-
     // Convert degrees to radians
     lon *= (Math.PI / 180);
     lat *= (Math.PI / 180);

--- a/src/geodetic.mjs
+++ b/src/geodetic.mjs
@@ -36,23 +36,23 @@ function geodeticToCartesian(lon, lat, alt) {
  * @returns {number[]} A geodetic coordinate as [longitude, latitude, altitude].
  */
 function cartesianToGeodetic(x, y, z) {
-    // Constants for WGS84 ellipsoid
-    const a = 6378137; // semi-major axis
-    const f = 1 / 298.257223563; // flattening
-    const b = a * (1 - f); // semi-minor axis
-    const e = Math.sqrt(2 * f - f * f); // eccentricity
+    const e2 = e * e; // eccentricity squared
+    const precision = 1e-12; // precision value for iterative refinement
 
     const p = Math.sqrt(x * x + z * z); // distance from minor axis
-    const th = Math.atan2(a * y, b * p); // angle between p and y
 
     // Calculate longitude
     let lon = Math.atan2(-z, x);
 
-    // Calculate latitude
-    let lat = Math.atan2((y + Math.pow(e, 2) * b * Math.pow(Math.sin(th), 3)), (p - Math.pow(e, 2) * a * Math.pow(Math.cos(th), 3)));
-
-    // Calculate N, the radius of curvature in the prime vertical
-    const N = a / Math.sqrt(1 - Math.pow(e, 2) * Math.sin(lat) * Math.sin(lat));
+    // Calculate latitude iteratively
+    let lat = Math.atan2(y, p * (1 - e2)); // initial latitude approximation
+    let latPrev = Infinity;
+    let N;
+    while (Math.abs(lat - latPrev) > precision) {
+        latPrev = lat;
+        N = a / Math.sqrt(1 - e2 * Math.sin(lat) * Math.sin(lat));
+        lat = Math.atan2(y + e2 * N * Math.sin(lat), p);
+    }
 
     // Calculate altitude
     const alt = p / Math.cos(lat) - N;


### PR DESCRIPTION
I came across an accuracy issue in the cartesianToGeodetic function:
```
const lon = 4.7325935;
const lat = 52.2977199;
const alt = 100.0;

const [x, y, z] = earthatile.geodeticToCartesian(lon, lat, alt);
const [_lon, _lat, _alt] = earthatile.cartesianToGeodetic(x, z, -y);

console.log(lon, lat, alt);    // 4.7325  52.2977   100
console.log(_lon, _lat, _alt); // 4.7325  52.2969  -11.9629
```

After consulting other libraries and AI I came with some adjustments that help make it more accurate:
```
console.log(lon, lat, alt);    // 4.7325  52.2977   100
console.log(_lon, _lat, _alt); // 4.7325  52.2977   99.9999
```